### PR TITLE
pc - remove menus from navbar; these aren't needed until team02

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,10 +79,10 @@
   },
   "nyc": {
     "check-coverage": true,
-    "lines": 80,
-    "statements": 80,
-    "branches": 80,
-    "functions": 80,
+    "lines": 100,
+    "statements": 100,
+    "branches": 100,
+    "functions": 100,
     "reporter": [
       "html",
       "text-summary"

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -58,21 +58,6 @@ export default function AppNavbar({
                   <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
                 </NavDropdown>
               )}
-              {currentUser && currentUser.loggedIn ? (
-                <>
-                  <Nav.Link as={Link} to="/restaurants">
-                    Restaurants
-                  </Nav.Link>
-                  <Nav.Link as={Link} to="/ucsbdates">
-                    UCSB Dates
-                  </Nav.Link>
-                  <Nav.Link as={Link} to="/placeholder">
-                    Placeholder
-                  </Nav.Link>
-                </>
-              ) : (
-                <></>
-              )}
             </Nav>
 
             <Nav className="ml-auto">


### PR DESCRIPTION
In this PR, we fix some issues with the frontend test coverage that were introduced when we updated team01 from the team02 code base.

We created team01 from a working team02 by *removing* some frontend code.  But we left a trace in the navbar that we forgot to remove.  That left some untested code; this PR fixes that by removing the navigation links from the navbar.

