### PR TITLE
Corrected Error Preventing creation of new UCSB Dates

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
@@ -84,7 +84,7 @@ public class UCSBDatesController extends ApiController {
     public UCSBDate postUCSBDate(
             @Parameter(name="quarterYYYYQ") @RequestParam String quarterYYYYQ,
             @Parameter(name="name") @RequestParam String name,
-            @Parameter(name="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
+            @Parameter(name="localDateTime", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime localDateTime)
             throws JsonProcessingException {
 
         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)


### PR DESCRIPTION
In this PR, I moved the explanation of the iso date format from the name to the description of the parameter, so that Swagger correctly submits the localDateTime parameter in the URL.

Before:
<img width="1076" alt="demo" src="https://github.com/user-attachments/assets/b9ada860-473a-4b71-89ef-8b6ff8cf389f">

After:
![image(1)](https://github.com/user-attachments/assets/cdd6f7f8-3297-45ba-b15d-ceacd67fa0db)
