### PR TITLE
pc - add stryker exception for tech debt in currentUser.js

### DIFF
--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -46,6 +46,7 @@ export function hasRole(currentUser, role) {
 
   if (currentUser == null) return false;
 
+  // Stryker disable next-line OptionalChaining : we should fix the hack rather than trying to test this bad code
   if (currentUser.data?.root?.rolesList) {
     return currentUser.data.root.rolesList.includes(role);
   }


### PR DESCRIPTION
In this PR, we add a stryker exception for a bit of code in `currentUser.js` that is a known piece of tech debt; an awful hack because of some bad architectural decisions.

In short, there is an ambiguity about the shape of the JSON returned by some of the API endpoints and services related to currentUser, and we've never fully resolved the problem.  Instead, there's some hacky code that "works" but isn't really very sound.

This Stryker exception isn't ideal, but it will get us through the day.